### PR TITLE
Fixing bug: futures of inner requests overwritten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
-1.0.4 (unreleased)
+1.0.5 (unreleased)
 ------------------
 
 - Nothing changed yet.
 
+
+1.0.4 (2018-07-04)
+------------------
+
+- Fixed bug with futures in inner requests being overwitten, causing
+  only the last request's futures being handled [lferran]
 
 1.0.3 (2018-06-27)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except IOError:
 
 setup(
     name='guillotina_batch',
-    version='1.0.4.dev0',
+    version='1.0.4',
     description='batch endpoint for guillotina',
     long_description=README,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Inner requests' futures had all the same the same id, and this was causing only the last request's futures being actually called.